### PR TITLE
Allow for basic sets of directly specified motions

### DIFF
--- a/src/bodies/bodies.jl
+++ b/src/bodies/bodies.jl
@@ -14,6 +14,7 @@ numpts(::Body{N}) where {N} = N
 numpts(::Nothing) = 0
 
 include("rigidbodymotions.jl")
+include("directmotions.jl")
 include("motionprofiles.jl")
 include("kinematics.jl")
 

--- a/src/bodies/bodylist.jl
+++ b/src/bodies/bodylist.jl
@@ -1,13 +1,15 @@
 import Base: @propagate_inbounds,getindex, setindex!,iterate,size,length,push!,
               collect,view
 
-export BodyList, RigidMotionList, RigidTransformList, getrange, numpts
+export BodyList, RigidMotionList, RigidTransformList, DirectlySpecifiedMotionList,
+          getrange, numpts
 
 abstract type SetOfBodies end
 
 const LISTS = [:BodyList, :Body],
               [:RigidMotionList, :RigidBodyMotion],
-              [:RigidTransformList, :RigidTransform]
+              [:RigidTransformList, :RigidTransform],
+              [:DirectlySpecifiedMotionList,:DirectlySpecifiedMotion]
 
 
 

--- a/src/bodies/directmotions.jl
+++ b/src/bodies/directmotions.jl
@@ -1,0 +1,5 @@
+abstract type DirectlySpecifiedMotion end
+
+struct BasicDirectMotion <: DirectlySpecifiedMotion
+
+end

--- a/src/bodies/directmotions.jl
+++ b/src/bodies/directmotions.jl
@@ -1,3 +1,5 @@
+export DirectlySpecifiedMotion, BasicDirectMotion
+
 abstract type DirectlySpecifiedMotion end
 
 struct BasicDirectMotion <: DirectlySpecifiedMotion

--- a/test/motions.jl
+++ b/test/motions.jl
@@ -92,3 +92,14 @@ Ay = rand()
 
 
 end
+
+@testset "Direct motions" begin
+
+  m = RigidBodyTools.BasicDirectMotion()
+
+  ml = RigidBodyTools.DirectlySpecifiedMotionList([m])
+
+  push!(ml,m)
+
+
+end


### PR DESCRIPTION
Now create lists of motions that are directly specified. Still needs to be merged better with RigidBodyMotion