### PR TITLE
Treat bodies with corners with option to shift points

### DIFF
--- a/src/RigidBodyTools.jl
+++ b/src/RigidBodyTools.jl
@@ -11,6 +11,10 @@ abstract type BodyClosureType end
 abstract type OpenBody <: BodyClosureType end
 abstract type ClosedBody <: BodyClosureType end
 
+abstract type PointShiftType end
+abstract type Unshifted <: PointShiftType end
+abstract type Shifted <: PointShiftType end
+
 abstract type Body{N,C<:BodyClosureType} end
 
 numpts(::Body{N}) where {N} = N

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -110,6 +110,11 @@ end
 Construct a rectangular body with x̃ side half-length `a` and ỹ side half-length `b`,
 with `na` points distributed on the x̃ side (including both corners). The centroid
 of the rectangle is placed at the origin (so that the lower left corner is at (-a,-b)).
+
+By default, points are placed at the corners, and the normal vectors are bisectors
+between the normals on the adjacent two sides. If the `shifted=true` flag is added,
+then the points are shifted counterclockwise by half a segment, so no points
+are placed on the corners, and all normals are perpendicular to the sides.
 """
 mutable struct Rectangle{N,PS} <: Body{N,ClosedBody}
   a :: Float64
@@ -190,9 +195,9 @@ end
 Construct a square body with side half-length `a`
 and with `na` points distributed on each side (including both corners).
 """
-Square(a::Real,na::Int) = Rectangle(a,a,na)
+Square(a::Real,na::Int;kwargs...) = Rectangle(a,a,na;kwargs...)
 
-Square(a::Real,targetsize::Float64) = Rectangle(a,a,targetsize)
+Square(a::Real,targetsize::Float64;kwargs...) = Rectangle(a,a,targetsize;kwargs...)
 
 function Base.show(io::IO, body::Rectangle{N}) where {N}
     if body.a == body.b

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -39,9 +39,25 @@ function _diff(x::Vector{Float64},y::Vector{Float64},::Type{ClosedBody})
   N = length(x)
   @assert N == length(y)
 
-  ip1(i) = 1+mod(i,N)
-  dxtmp = [x[ip1(i)] - x[i] for i = 1:N]
-  dytmp = [y[ip1(i)] - y[i] for i = 1:N]
+  dxtmp = circshift(x,-1) .- x
+  dytmp = circshift(y,-1) .- y
+  #ip1(i) = 1+mod(i,N)
+  #dxtmp = [x[ip1(i)] - x[i] for i = 1:N]
+  #dytmp = [y[ip1(i)] - y[i] for i = 1:N]
+
+  return dxtmp, dytmp
+
+end
+
+function _diff_ccw(x::Vector{Float64},y::Vector{Float64},::Type{ClosedBody})
+  N = length(x)
+  @assert N == length(y)
+
+  dxtmp = x .- circshift(x,1)
+  dytmp = y .- circshift(y,1)
+  #ip1(i) = 1+mod(i,N)
+  #dxtmp = [x[ip1(i)] - x[i] for i = 1:N]
+  #dytmp = [y[ip1(i)] - y[i] for i = 1:N]
 
   return dxtmp, dytmp
 
@@ -81,9 +97,24 @@ function _midpoints(x::Vector{Float64},y::Vector{Float64},::Type{ClosedBody})
   N = length(x)
   @assert N == length(y)
 
-  ip1(i) = 1+mod(i,N)
-  xc = 0.5*[x[ip1(i)] + x[i] for i = 1:N]
-  yc = 0.5*[y[ip1(i)] + y[i] for i = 1:N]
+  #ip1(i) = 1+mod(i,N)
+  #xc = 0.5*[x[ip1(i)] + x[i] for i = 1:N]
+  #yc = 0.5*[y[ip1(i)] + y[i] for i = 1:N]
+
+  xc = 0.5*(x .+ circshift(x,-1))
+  yc = 0.5*(y .+ circshift(y,-1))
+
+  return xc, yc
+
+end
+
+function _midpoints_ccw(x::Vector{Float64},y::Vector{Float64},::Type{ClosedBody})
+
+  N = length(x)
+  @assert N == length(y)
+
+  xc = 0.5*(x .+ circshift(x,1))
+  yc = 0.5*(y .+ circshift(y,1))
 
   return xc, yc
 

--- a/test/bodies.jl
+++ b/test/bodies.jl
@@ -1,5 +1,7 @@
 using Statistics
 
+const MYEPS = 20*eps()
+
 @testset "Bodies" begin
 
   bn = nothing
@@ -32,6 +34,42 @@ using Statistics
   @test nx[1] == ny[26] == -nx[51] == -ny[76] == 1.0
   @test abs(sum(nx)) < 1000.0*eps(1.0)
   @test abs(sum(ny)) < 1000.0*eps(1.0)
+
+
+end
+
+@testset "Shifted rectangle" begin
+
+  b = Rectangle(0.5,1.0,11,shifted=true)
+  nx, ny = normalmid(b)
+  nx, ny = normalmid(b)
+  @test all(isapprox.(nx[1:10],0.0,atol=MYEPS)) &&
+        all(isapprox.(nx[11:30],1.0,atol=MYEPS)) &&
+        all(isapprox.(nx[31:40],0.0,atol=MYEPS)) &&
+        all(isapprox.(nx[41:60],-1.0,atol=MYEPS))
+  @test all(isapprox.(ny[1:10],-1.0,atol=MYEPS)) &&
+        all(isapprox.(ny[11:30],0.0,atol=MYEPS)) &&
+        all(isapprox.(ny[31:40],1.0,atol=MYEPS)) &&
+        all(isapprox.(ny[41:60],0.0,atol=MYEPS))
+
+  ds = dlengthmid(b)
+  @test all(ds .≈ 0.1)
+
+  T = RigidTransform((1.0,-1.0),π/2)
+  T(b)
+
+  nx, ny = normalmid(b)
+  @test all(isapprox.(nx[1:10],1.0,atol=MYEPS)) &&
+        all(isapprox.(nx[11:30],0.0,atol=MYEPS)) &&
+        all(isapprox.(nx[31:40],-1.0,atol=MYEPS)) &&
+        all(isapprox.(nx[41:60],0.0,atol=MYEPS))
+  @test all(isapprox.(ny[1:10],0.0,atol=MYEPS)) &&
+        all(isapprox.(ny[11:30],1.0,atol=MYEPS)) &&
+        all(isapprox.(ny[31:40],0.0,atol=MYEPS)) &&
+        all(isapprox.(ny[41:60],-1.0,atol=MYEPS))
+
+  ds = dlengthmid(b)
+  @test all(ds .≈ 0.1)
 
 
 end
@@ -74,6 +112,16 @@ end
   @test bl[2].cent == tl[2].trans
   @test bl[1].α == tl[1].α
   @test bl[2].α == tl[2].α
+
+  b1 = Rectangle(0.5,1.0,11,shifted=true)
+  b2 = Rectangle(0.5,1.0,11,shifted=false)
+  bl = BodyList()
+  push!(bl,b1)
+  push!(bl,b2)
+  nx, ny = normalmid(bl)
+  nxb1, nyb1 = normalmid(b1)
+  nxb2, nyb2 = normalmid(b2)
+  @test nx[1:60] == nxb1 && ny[1:60] == nyb1 && nx[61:120] == nxb2 && ny[61:120] == nyb2
 
 
 end


### PR DESCRIPTION
This PR allows a `shifted=true` flag for `Rectangle` and `Square` bodies, which shifts points by half a segment from the corners. This ensures that normal vectors are perpendicular to sides at all points.