### PR TITLE
Merge motion types

### DIFF
--- a/src/RigidBodyTools.jl
+++ b/src/RigidBodyTools.jl
@@ -2,9 +2,14 @@ module RigidBodyTools
 
 
 export Body
+export RigidBodyMotion, Kinematics, d_dt, motion_velocity, assign_velocity!, assign_velocity
+export Oscillation, OscillationX, OscillationY, OscillationXY, RotationalOscillation,
+        PitchHeave, Pitchup, EldredgeRamp, ColoniusRamp
+
 
 const NDIM = 2
 const CHUNK = 3*(NDIM-1)
+
 
 
 abstract type BodyClosureType end
@@ -17,15 +22,20 @@ abstract type Shifted <: PointShiftType end
 
 abstract type Body{N,C<:BodyClosureType} end
 
+
+
+abstract type AbstractMotion end
+
+
 numpts(::Body{N}) where {N} = N
 numpts(::Nothing) = 0
 
+include("kinematics.jl")
 include("rigidbodymotions.jl")
 include("directmotions.jl")
-include("kinematics.jl")
 
 include("rigidtransform.jl")
-include("bodylist.jl")
+include("lists.jl")
 
 
 include("tools.jl")

--- a/src/RigidBodyTools.jl
+++ b/src/RigidBodyTools.jl
@@ -5,7 +5,7 @@ import Base: vec
 
 export Body
 export RigidBodyMotion, Kinematics, d_dt, motion_velocity, motion_state,
-          surface_velocity!, surface_velocity
+          surface_velocity!, surface_velocity, DirectlySpecifiedMotion
 export Oscillation, OscillationX, OscillationY, OscillationXY, RotationalOscillation,
         PitchHeave, Pitchup, EldredgeRamp, ColoniusRamp
 

--- a/src/RigidBodyTools.jl
+++ b/src/RigidBodyTools.jl
@@ -2,7 +2,7 @@ module RigidBodyTools
 
 
 export Body
-export RigidBodyMotion, Kinematics, d_dt, motion_velocity, assign_velocity!, assign_velocity
+export RigidBodyMotion, Kinematics, d_dt, motion_velocity, surface_velocity!, surface_velocity
 export Oscillation, OscillationX, OscillationY, OscillationXY, RotationalOscillation,
         PitchHeave, Pitchup, EldredgeRamp, ColoniusRamp
 
@@ -21,8 +21,6 @@ abstract type Unshifted <: PointShiftType end
 abstract type Shifted <: PointShiftType end
 
 abstract type Body{N,C<:BodyClosureType} end
-
-
 
 abstract type AbstractMotion end
 

--- a/src/RigidBodyTools.jl
+++ b/src/RigidBodyTools.jl
@@ -1,8 +1,11 @@
 module RigidBodyTools
 
+import Base: vec
+
 
 export Body
-export RigidBodyMotion, Kinematics, d_dt, motion_velocity, surface_velocity!, surface_velocity
+export RigidBodyMotion, Kinematics, d_dt, motion_velocity, motion_state,
+          surface_velocity!, surface_velocity
 export Oscillation, OscillationX, OscillationY, OscillationXY, RotationalOscillation,
         PitchHeave, Pitchup, EldredgeRamp, ColoniusRamp
 

--- a/src/assignvelocity.jl
+++ b/src/assignvelocity.jl
@@ -1,22 +1,22 @@
 """
     assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 body::Body,motion::RigidBodyMotion,t::Real)
+                 body::Body,motion::AbstractMotion,t::Real)
 
-Assign the components of rigid body velocity `u` and `v` (in inertial coordinate system)
+Assign the components of body velocity `u` and `v` (in inertial coordinate system)
 at positions described by coordinates inertial coordinates in body in `body` at time `t`,
-based on supplied motions in the RigidBodyMotion `motion` for the body.
+based on supplied motions in the `motion` for the body.
 """
 assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 b::Body,m::Union{RigidBodyMotion,DirectlySpecifiedMotion},t::Real) =
+                 b::Body,m::RigidBodyMotion,t::Real) =
                  assign_velocity!(u,v,b.x,b.y,b.cent...,b.α,m,t)
 
 assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                  b::Body,m::DirectlySpecifiedMotion,t::Real) =
-                 assign_velocity!(u,v,b.x,b.y,b.cent...,b.α,m,t)
+                 assign_velocity!(u,v,b.x,b.y,m,t)
 
 
 """
-    assign_velocity(body::Body,motion::RigidBodyMotion,t::Real)
+    assign_velocity(body::Body,motion::AbstractMotion,t::Real)
 
 Return the components of rigid body velocity (in inertial coordinate system)
 at positions described by coordinates inertial coordinates in body in `body` at time `t`,
@@ -34,14 +34,14 @@ assign_velocity(b::Body,a...) = assign_velocity!(zero(b.x),zero(b.y),b,a...)
 
 """
     assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                     bl::BodyList,ml::RigidMotionList,t::Real)
+                     bl::BodyList,ml::MotionList,t::Real)
 
-Assign the components of rigid body velocity `u` and `v` (in inertial coordinate system)
+Assign the components of velocity `u` and `v` (in inertial coordinate system)
 at positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
-based on supplied motions in the RigidMotionList `ml` for each body.
+based on supplied motions in the MotionList `ml` for each body.
 """
 function assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 bl::BodyList,ml::Union{RigidMotionList,DirectlySpecifiedMotionList},t::Real)
+                 bl::BodyList,ml::MotionList,t::Real)
 
    for i in 1:length(bl)
       assign_velocity!(view(u,bl,i),view(v,bl,i),bl[i],ml[i],t)
@@ -50,17 +50,15 @@ function assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
 end
 
 """
-    assign_velocity(bl::BodyList,ml::RigidMotionList,t::Real)
+    assign_velocity(bl::BodyList,ml::MotionList,t::Real)
 
 Return the components of rigid body velocity (in inertial coordinate system)
 at positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
-based on supplied motions in the RigidMotionList `ml` for each body.
+based on supplied motions in the MotionList `ml` for each body.
 
 As a shorthand, you an also apply this as `ml(t,bl)`.
 """
-assign_velocity(bl::BodyList,ml::Union{RigidMotionList,DirectlySpecifiedMotionList},t::Real) =
+assign_velocity(bl::BodyList,ml::MotionList,t::Real) =
     assign_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t)
 
-(ml::RigidMotionList)(t::Real,bl::BodyList) = assign_velocity(bl,ml,t)
-
-(ml::DirectlySpecifiedMotionList)(t::Real,bl::BodyList) = assign_velocity(bl,ml,t)
+(ml::MotionList)(t::Real,bl::BodyList) = assign_velocity(bl,ml,t)

--- a/src/assignvelocity.jl
+++ b/src/assignvelocity.jl
@@ -10,9 +10,7 @@ surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                  b::Body,m::RigidBodyMotion,t::Real) =
                  surface_velocity!(u,v,b.x,b.y,b.cent...,b.α,m,t)
 
-surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 b::Body,m::DirectlySpecifiedMotion,t::Real) =
-                 surface_velocity!(u,v,b.x,b.y,m,t)
+
 
 
 """

--- a/src/assignvelocity.jl
+++ b/src/assignvelocity.jl
@@ -1,62 +1,15 @@
 """
-    surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 body::Body,motion::AbstractMotion,t::Real)
-
-Assign the components of body velocity `u` and `v` (in inertial coordinate system)
-at surface positions described by coordinates inertial coordinates in body in `body` at time `t`,
-based on supplied motions in the `motion` for the body.
-"""
-surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 b::Body,m::RigidBodyMotion,t::Real) =
-                 surface_velocity!(u,v,b.x,b.y,b.cent...,b.α,m,t)
-
-
-
-
-"""
     surface_velocity(body::Body,motion::AbstractMotion,t::Real)
 
 Return the components of rigid body velocity (in inertial coordinate system)
 at surface positions described by coordinates inertial coordinates in body in `body` at time `t`,
-based on supplied motions in the RigidBodyMotion `motion` for the body.
+based on supplied motions in `motion` for the body.
 
 As a shorthand, you can also apply this as `motion(t,body)`.
 """
 surface_velocity(b::Body,a...) = surface_velocity!(zero(b.x),zero(b.y),b,a...)
 
 
-(m::RigidBodyMotion)(t::Real,b::Body) = surface_velocity(b,m,t)
+#(m::RigidBodyMotion)(t::Real,b::Body) = surface_velocity(b,m,t)
 
-(m::DirectlySpecifiedMotion)(t::Real,b::Body) = surface_velocity(b,m,t)
-
-
-"""
-    surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                     bl::BodyList,ml::MotionList,t::Real)
-
-Assign the components of velocity `u` and `v` (in inertial coordinate system)
-at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
-based on supplied motions in the MotionList `ml` for each body.
-"""
-function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 bl::BodyList,ml::MotionList,t::Real)
-
-   for i in 1:length(bl)
-      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],ml[i],t)
-   end
-   return u, v
-end
-
-"""
-    surface_velocity(bl::BodyList,ml::MotionList,t::Real)
-
-Return the components of rigid body velocity (in inertial coordinate system)
-at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
-based on supplied motions in the MotionList `ml` for each body.
-
-As a shorthand, you an also apply this as `ml(t,bl)`.
-"""
-surface_velocity(bl::BodyList,ml::MotionList,t::Real) =
-    surface_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t)
-
-(ml::MotionList)(t::Real,bl::BodyList) = surface_velocity(bl,ml,t)
+#(m::DirectlySpecifiedMotion)(t::Real,b::Body) = surface_velocity(b,m,t)

--- a/src/assignvelocity.jl
+++ b/src/assignvelocity.jl
@@ -1,64 +1,64 @@
 """
-    assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+    surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                  body::Body,motion::AbstractMotion,t::Real)
 
 Assign the components of body velocity `u` and `v` (in inertial coordinate system)
-at positions described by coordinates inertial coordinates in body in `body` at time `t`,
+at surface positions described by coordinates inertial coordinates in body in `body` at time `t`,
 based on supplied motions in the `motion` for the body.
 """
-assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                  b::Body,m::RigidBodyMotion,t::Real) =
-                 assign_velocity!(u,v,b.x,b.y,b.cent...,b.α,m,t)
+                 surface_velocity!(u,v,b.x,b.y,b.cent...,b.α,m,t)
 
-assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                  b::Body,m::DirectlySpecifiedMotion,t::Real) =
-                 assign_velocity!(u,v,b.x,b.y,m,t)
+                 surface_velocity!(u,v,b.x,b.y,m,t)
 
 
 """
-    assign_velocity(body::Body,motion::AbstractMotion,t::Real)
+    surface_velocity(body::Body,motion::AbstractMotion,t::Real)
 
 Return the components of rigid body velocity (in inertial coordinate system)
-at positions described by coordinates inertial coordinates in body in `body` at time `t`,
+at surface positions described by coordinates inertial coordinates in body in `body` at time `t`,
 based on supplied motions in the RigidBodyMotion `motion` for the body.
 
 As a shorthand, you can also apply this as `motion(t,body)`.
 """
-assign_velocity(b::Body,a...) = assign_velocity!(zero(b.x),zero(b.y),b,a...)
+surface_velocity(b::Body,a...) = surface_velocity!(zero(b.x),zero(b.y),b,a...)
 
 
-(m::RigidBodyMotion)(t::Real,b::Body) = assign_velocity(b,m,t)
+(m::RigidBodyMotion)(t::Real,b::Body) = surface_velocity(b,m,t)
 
-(m::DirectlySpecifiedMotion)(t::Real,b::Body) = assign_velocity(b,m,t)
+(m::DirectlySpecifiedMotion)(t::Real,b::Body) = surface_velocity(b,m,t)
 
 
 """
-    assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+    surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                      bl::BodyList,ml::MotionList,t::Real)
 
 Assign the components of velocity `u` and `v` (in inertial coordinate system)
-at positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
+at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
 based on supplied motions in the MotionList `ml` for each body.
 """
-function assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                  bl::BodyList,ml::MotionList,t::Real)
 
    for i in 1:length(bl)
-      assign_velocity!(view(u,bl,i),view(v,bl,i),bl[i],ml[i],t)
+      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],ml[i],t)
    end
    return u, v
 end
 
 """
-    assign_velocity(bl::BodyList,ml::MotionList,t::Real)
+    surface_velocity(bl::BodyList,ml::MotionList,t::Real)
 
 Return the components of rigid body velocity (in inertial coordinate system)
-at positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
+at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
 based on supplied motions in the MotionList `ml` for each body.
 
 As a shorthand, you an also apply this as `ml(t,bl)`.
 """
-assign_velocity(bl::BodyList,ml::MotionList,t::Real) =
-    assign_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t)
+surface_velocity(bl::BodyList,ml::MotionList,t::Real) =
+    surface_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t)
 
-(ml::MotionList)(t::Real,bl::BodyList) = assign_velocity(bl,ml,t)
+(ml::MotionList)(t::Real,bl::BodyList) = surface_velocity(bl,ml,t)

--- a/src/directmotions.jl
+++ b/src/directmotions.jl
@@ -1,7 +1,39 @@
 export DirectlySpecifiedMotion, BasicDirectMotion
 
-abstract type DirectlySpecifiedMotion end
+abstract type DirectlySpecifiedMotion <: AbstractMotion end
 
-struct BasicDirectMotion <: DirectlySpecifiedMotion
-
+struct BasicDirectMotion{VT} <: DirectlySpecifiedMotion
+    u :: VT
+    v :: VT
 end
+
+
+"""
+    assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+                     x::AbstractVector{Float64},y::AbstractVector{Float64},
+                     motion::BasicDirectMotion,t::Real)
+
+Assign the components of velocity `u` and `v` (in inertial coordinate system)
+at positions described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
+based on supplied motion `motion` for the body.
+"""
+function assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+                          x::AbstractVector{Float64},y::AbstractVector{Float64},
+                          m::BasicDirectMotion,t::Real)
+
+  u .= m.u
+  v .= m.v
+  return u, v
+end
+
+"""
+    assign_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
+                    motion::BasicDirectMotion,t::Real)
+
+Return the components of velocities (in inertial components) at positions
+described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
+based on supplied motion `motion` for the body.
+"""
+assign_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
+                m::BasicDirectMotion,t::Real) =
+                assign_velocity!(similar(x),similar(y),x,y,m,t)

--- a/src/directmotions.jl
+++ b/src/directmotions.jl
@@ -9,15 +9,15 @@ end
 
 
 """
-    assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+    surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                      x::AbstractVector{Float64},y::AbstractVector{Float64},
                      motion::BasicDirectMotion,t::Real)
 
 Assign the components of velocity `u` and `v` (in inertial coordinate system)
-at positions described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
+at surface positions described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
 based on supplied motion `motion` for the body.
 """
-function assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                           x::AbstractVector{Float64},y::AbstractVector{Float64},
                           m::BasicDirectMotion,t::Real)
 
@@ -27,13 +27,13 @@ function assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
 end
 
 """
-    assign_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
+    surface_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
                     motion::BasicDirectMotion,t::Real)
 
-Return the components of velocities (in inertial components) at positions
+Return the components of velocities (in inertial components) at surface positions
 described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
 based on supplied motion `motion` for the body.
 """
-assign_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
+surface_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
                 m::BasicDirectMotion,t::Real) =
-                assign_velocity!(similar(x),similar(y),x,y,m,t)
+                surface_velocity!(similar(x),similar(y),x,y,m,t)

--- a/src/directmotions.jl
+++ b/src/directmotions.jl
@@ -4,12 +4,7 @@ abstract type DirectlySpecifiedMotion <: AbstractMotion end
 
 #=
 To create a subtype of DirectlySpecifiedMotion, one must
-extend `motion_velocity(m,t)` to convert the instantaneous
-velocity components into a vector (e.g., to be used for
-advancing the associated points in a time-marching scheme),
-`motion_state(b,m)` to convert the instantaneous coordinates
-of body `b` into a state vector,
-and `surface_velocity!(u,v,body,m,t)`, to supply the
+extend `surface_velocity!(u,v,body,m,t)`, to supply the
 surface values of the motion in-place in vectors `u` and `v`,
 which must be of the same length as `b.x` and `b.y`.
 =#
@@ -18,28 +13,6 @@ struct BasicDirectMotion{VT} <: DirectlySpecifiedMotion
     u :: VT
     v :: VT
 end
-
-
-"""
-    motion_velocity(m::BasicDirectMotion,t::Real)
-
-Return the velocity components (as a vector) of a `BasicDirectMotion`
-at the given time `t`.
-"""
-motion_velocity(m::BasicDirectMotion,t::Real) = vcat(m.u,m.v)
-
-
-"""
-    motion_state(b::Body,m::BasicDirectMotion)
-
-Return the current state vector of body `b` associated with
-direct motion `m`. It returns the concatenated coordinates
-of the body surface (in the inertial coordinate system).
-"""
-function motion_state(b::Body,m::BasicDirectMotion)
-    return vcat(b.x,b.y)
-end
-
 
 """
     surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
@@ -50,7 +23,7 @@ at surface positions described by points in body `b` (also in inertial coordinat
 based on supplied motion `motion` for the body.
 """
 function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                           b::Body,m::DirectlySpecifiedMotion,t::Real)
+                           b::Body,m::BasicDirectMotion,t::Real)
      u .= m.u
      v .= m.v
      return u, v
@@ -58,11 +31,41 @@ end
 
 
 """
-    surface_velocity(b::Body,motion::BasicDirectMotion,t::Real)
+    motion_velocity(b::Body,m::DirectlySpecifiedMotion,t::Real)
+
+Return the velocity components (as a vector) of a `DirectlySpecifiedMotion`
+at the given time `t`.
+"""
+function motion_velocity(b::Body,m::DirectlySpecifiedMotion,t::Real)
+    u, v = zero(b.x), zero(b.y)
+    surface_velocity!(u,v,b,m,t)
+    return vcat(u,v)
+end
+
+
+"""
+    motion_state(b::Body,m::DirectlySpecifiedMotion)
+
+Return the current state vector of body `b` associated with
+direct motion `m`. It returns the concatenated coordinates
+of the body surface (in the inertial coordinate system).
+"""
+function motion_state(b::Body,m::DirectlySpecifiedMotion)
+    return vcat(b.x,b.y)
+end
+
+
+
+
+#=
+"""
+    surface_velocity(b::Body,motion::DirectlySpecifiedMotion,t::Real)
 
 Return the components of velocities (in inertial components) at surface positions
 described by points in body `b` (also in inertial coordinate system) at time `t`,
 based on supplied motion `motion` for the body.
 """
-surface_velocity(b::Body,m::BasicDirectMotion,t::Real) =
+surface_velocity(b::Body,m::DirectlySpecifiedMotion,t::Real) =
                 surface_velocity!(similar(b.x),similar(b.y),b,m,t)
+
+=#

--- a/src/directmotions.jl
+++ b/src/directmotions.jl
@@ -2,6 +2,18 @@ export DirectlySpecifiedMotion, BasicDirectMotion
 
 abstract type DirectlySpecifiedMotion <: AbstractMotion end
 
+#=
+To create a subtype of DirectlySpecifiedMotion, one must
+extend `motion_velocity(m,t)` to convert the instantaneous
+velocity components into a vector (e.g., to be used for
+advancing the associated points in a time-marching scheme),
+`motion_state(b,m)` to convert the instantaneous coordinates
+of body `b` into a state vector,
+and `surface_velocity!(u,v,body,m,t)`, to supply the
+surface values of the motion in-place in vectors `u` and `v`,
+which must be of the same length as `b.x` and `b.y`.
+=#
+
 struct BasicDirectMotion{VT} <: DirectlySpecifiedMotion
     u :: VT
     v :: VT
@@ -9,31 +21,48 @@ end
 
 
 """
+    motion_velocity(m::BasicDirectMotion,t::Real)
+
+Return the velocity components (as a vector) of a `BasicDirectMotion`
+at the given time `t`.
+"""
+motion_velocity(m::BasicDirectMotion,t::Real) = vcat(m.u,m.v)
+
+
+"""
+    motion_state(b::Body,m::BasicDirectMotion)
+
+Return the current state vector of body `b` associated with
+direct motion `m`. It returns the concatenated coordinates
+of the body surface (in the inertial coordinate system).
+"""
+function motion_state(b::Body,m::BasicDirectMotion)
+    return vcat(b.x,b.y)
+end
+
+
+"""
     surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                     x::AbstractVector{Float64},y::AbstractVector{Float64},
-                     motion::BasicDirectMotion,t::Real)
+                     b::Body,motion::BasicDirectMotion,t::Real)
 
 Assign the components of velocity `u` and `v` (in inertial coordinate system)
-at surface positions described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
+at surface positions described by points in body `b` (also in inertial coordinate system) at time `t`,
 based on supplied motion `motion` for the body.
 """
 function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                          x::AbstractVector{Float64},y::AbstractVector{Float64},
-                          m::BasicDirectMotion,t::Real)
-
-  u .= m.u
-  v .= m.v
-  return u, v
+                           b::Body,m::DirectlySpecifiedMotion,t::Real)
+     u .= m.u
+     v .= m.v
+     return u, v
 end
 
+
 """
-    surface_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
-                    motion::BasicDirectMotion,t::Real)
+    surface_velocity(b::Body,motion::BasicDirectMotion,t::Real)
 
 Return the components of velocities (in inertial components) at surface positions
-described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
+described by points in body `b` (also in inertial coordinate system) at time `t`,
 based on supplied motion `motion` for the body.
 """
-surface_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
-                m::BasicDirectMotion,t::Real) =
-                surface_velocity!(similar(x),similar(y),x,y,m,t)
+surface_velocity(b::Body,m::BasicDirectMotion,t::Real) =
+                surface_velocity!(similar(b.x),similar(b.y),b,m,t)

--- a/src/kinematics.jl
+++ b/src/kinematics.jl
@@ -22,15 +22,15 @@ Constant(ċ, α̇) = Constant(complex(ċ), α̇)
 show(io::IO, c::Constant) = print(io, "Constant (ċ = $(c.ċ), α̇ = $(c.α̇))")
 
 """
-    Pitchup(U₀,a,K,α₀,t₀,Δα,ramp=EldredgeRamp) <: Kinematics
+    Pitchup(U₀,a,K,α₀,t₀,Δα,ramp=EldredgeRamp(11.0)) <: Kinematics
 
 Kinematics describing a pitch-ramp motion (horizontal translation with rotation)
 starting at time ``t_0`` about an axis at `a` (expressed relative to the centroid, in the ``\\tilde{x}``
   direction in the body-fixed coordinate system), with translational velocity `U₀`
 in the inertial ``x`` direction, initial angle ``\\alpha_0``, and angular
 change ``\\Delta\\alpha``. The optional ramp argument is assumed to be
-given by the smooth ramp `EldredgeRamp`, though this can be changed to
-`ColoniusRamp`.
+given by the smooth ramp `EldredgeRamp` with a smoothness factor of 11, but this
+can be replaced by another Eldredge ramp with a different value or a `ColoniusRamp`.
 """
 struct Pitchup <: Kinematics
     "Freestream velocity"
@@ -54,7 +54,7 @@ struct Pitchup <: Kinematics
     α̈::Abstract1DProfile
 end
 
-function Pitchup(U₀, a, K, α₀, t₀, Δα, ramp=EldredgeRamp)
+function Pitchup(U₀, a, K, α₀, t₀, Δα, ramp=EldredgeRamp(11.0))
     Δt = 0.5Δα/K
     p = ConstantProfile(α₀) + 2K*((ramp >> t₀) - (ramp >> (t₀ + Δt)))
     ṗ = d_dt(p)

--- a/src/kinematics.jl
+++ b/src/kinematics.jl
@@ -1,9 +1,17 @@
 #=
 Kinematics
 =#
+using DocStringExtensions
+import ForwardDiff
+import Base: +, *, -, >>, <<, show
 
 using SpaceTimeFields
 import SpaceTimeFields: Abstract1DProfile, >>, ConstantProfile, d_dt
+
+"""
+An abstract type for types that takes in time and returns `(c, ċ, c̈, α, α̇, α̈)`.
+"""
+abstract type Kinematics end
 
 struct Constant{C <: Complex, A <: Real} <: Kinematics
     ċ::C

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -1,15 +1,14 @@
 import Base: @propagate_inbounds,getindex, setindex!,iterate,size,length,push!,
               collect,view
 
-export BodyList, RigidMotionList, RigidTransformList, DirectlySpecifiedMotionList,
+export BodyList, MotionList, RigidTransformList,
           getrange, numpts
 
 abstract type SetOfBodies end
 
 const LISTS = [:BodyList, :Body],
-              [:RigidMotionList, :RigidBodyMotion],
-              [:RigidTransformList, :RigidTransform],
-              [:DirectlySpecifiedMotionList,:DirectlySpecifiedMotion]
+              [:MotionList, :AbstractMotion],
+              [:RigidTransformList, :RigidTransform]
 
 
 
@@ -135,15 +134,15 @@ end
 _length_and_mod(x::Vector{T}) where T <: Real = (n = length(x); return n ÷ CHUNK, n % CHUNK)
 
 """
-    rigidbodyvelocity(ml::RigidMotionList,t::Real) -> Vector
+    motion_velocity(ml::MotionList,t::Real) -> Vector
 
-Return the velocity components (as a vector) of a `RigidMotionList`
+Return the aggregated velocity components (as a vector) of a `MotionList`
 at the given time `t`.
 """
-function rigidbodyvelocity(ml::Union{RigidMotionList,DirectlySpecifiedMotionList},t::Real)
+function motion_velocity(ml::MotionList,t::Real)
     u = Float64[]
     for m in ml
-      ui = rigidbodyvelocity(m,t)
+      ui = motion_velocity(m,t)
       append!(u,ui)
     end
     return u

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -147,3 +147,20 @@ function motion_velocity(ml::MotionList,t::Real)
     end
     return u
 end
+
+"""
+    motion_state(bl::BodyList,ml::MotionList)
+
+Return the current state vector of body list `bl` associated with
+motion list `ml`. It returns the aggregated state vectors
+of each body.
+"""
+function motion_state(bl::BodyList,ml::MotionList)
+    x = Float64[]
+    length(bl) == length(ml) || error("body and motion lists are not the same length")
+    for (b,m) in zip(bl,ml)
+      xi = motion_state(b,m)
+      append!(x,xi)
+    end
+    return x
+end

--- a/src/rigidbodymotions.jl
+++ b/src/rigidbodymotions.jl
@@ -49,12 +49,12 @@ end
 
 
 """
-    motion_velocity(m::RigidBodyMotion,t::Real)
+    motion_velocity(b::Body,m::RigidBodyMotion,t::Real)
 
 Return the velocity components (as a vector) of a `RigidBodyMotion`
 at the given time `t`.
 """
-function motion_velocity(motion::RigidBodyMotion,t::Real)
+function motion_velocity(b::Body,motion::RigidBodyMotion,t::Real)
   _,ċ,_,_,α̇,_ = motion(t)
   return [real(ċ),imag(ċ),α̇]
 end
@@ -69,6 +69,18 @@ of the body centroid and the angle of the body.
 function motion_state(b::Body,m::RigidBodyMotion)
     return [b.cent...,b.α]
 end
+
+"""
+    surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+                 body::Body,motion::AbstractMotion,t::Real)
+
+Assign the components of body velocity `u` and `v` (in inertial coordinate system)
+at surface positions described by coordinates inertial coordinates in body in `body` at time `t`,
+based on supplied motions in the `motion` for the body.
+"""
+surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+                 b::Body,m::RigidBodyMotion,t::Real) =
+                 surface_velocity!(u,v,b.x,b.y,b.cent...,b.α,m,t)
 
 """
     surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},

--- a/src/rigidbodymotions.jl
+++ b/src/rigidbodymotions.jl
@@ -47,6 +47,7 @@ function (m::RigidBodyMotion)(t,x̃::Tuple{Real,Real})
   return m.c + z, m.ċ + im*m.α̇*z, m.c̈ + (im*m.α̈-m.α̇^2)*z
 end
 
+
 """
     motion_velocity(m::RigidBodyMotion,t::Real)
 
@@ -56,6 +57,17 @@ at the given time `t`.
 function motion_velocity(motion::RigidBodyMotion,t::Real)
   _,ċ,_,_,α̇,_ = motion(t)
   return [real(ċ),imag(ċ),α̇]
+end
+
+"""
+    motion_state(b::Body,m::RigidBodyMotion)
+
+Return the current state vector of body `b` associated with
+rigid body motion `m`. It returns the current coordinates
+of the body centroid and the angle of the body.
+"""
+function motion_state(b::Body,m::RigidBodyMotion)
+    return [b.cent...,b.α]
 end
 
 """

--- a/src/rigidbodymotions.jl
+++ b/src/rigidbodymotions.jl
@@ -1,6 +1,6 @@
-
-
-
+#=
+Rigid body motions
+=#
 
 
 """
@@ -59,16 +59,16 @@ function motion_velocity(motion::RigidBodyMotion,t::Real)
 end
 
 """
-    assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+    surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                      x::AbstractVector{Float64},y::AbstractVector{Float64},
                      xc::Real,yc::Real,α::Real,
                      motion::RigidBodyMotion,t::Real)
 
 Assign the components of rigid body velocity `u` and `v` (in inertial coordinate system)
-at positions described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
+at surface positions described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
 based on supplied motion `motion` for the body.
 """
-function assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                           x::AbstractVector{Float64},y::AbstractVector{Float64},
                           xc::Real,yc::Real,α::Real,m::RigidBodyMotion,t::Real)
 
@@ -90,16 +90,16 @@ function assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
 end
 
 """
-    assign_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
+    surface_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
                     xc::Real,yc::Real,α::Real,motion::RigidBodyMotion,t::Real)
 
-Return the components of rigid body velocities (in inertial components) at positions
+Return the components of rigid body velocities (in inertial components) at surface positions
 described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
 based on supplied motion `motion` for the body.
 """
-assign_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
+surface_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
                 xc::Real,yc::Real,α::Real,m::RigidBodyMotion,t::Real) =
-                assign_velocity!(similar(x),similar(y),x,y,xc,yc,α,m,t)
+                surface_velocity!(similar(x),similar(y),x,y,xc,yc,α,m,t)
 
 
 function show(io::IO, m::RigidBodyMotion)

--- a/src/rigidbodymotions.jl
+++ b/src/rigidbodymotions.jl
@@ -1,20 +1,10 @@
 
-export RigidBodyMotion, Kinematics, d_dt, rigidbodyvelocity, assign_velocity!, assign_velocity
-export Oscillation, OscillationX, OscillationY, OscillationXY, RotationalOscillation,
-        PitchHeave, Pitchup, EldredgeRamp, ColoniusRamp
 
-using DocStringExtensions
-import ForwardDiff
-import Base: +, *, -, >>, <<, show
 
-"""
-An abstract type for types that takes in time and returns `(c, ċ, c̈, α, α̇, α̈)`.
-"""
-abstract type Kinematics end
 
 
 """
-    RigidBodyMotion
+    RigidBodyMotion <: AbstractMotion
 
 A type to store the body's current kinematics
 
@@ -31,7 +21,7 @@ A type to store the body's current kinematics
 The first six fields are meant as a cache of the current kinematics
 while the `kin` field can be used to find the plate kinematics at any time.
 """
-mutable struct RigidBodyMotion
+mutable struct RigidBodyMotion <: AbstractMotion
     c::ComplexF64
     ċ::ComplexF64
     c̈::ComplexF64
@@ -58,12 +48,12 @@ function (m::RigidBodyMotion)(t,x̃::Tuple{Real,Real})
 end
 
 """
-    rigidbodyvelocity(m::RigidBodyMotion,t::Real)
+    motion_velocity(m::RigidBodyMotion,t::Real)
 
 Return the velocity components (as a vector) of a `RigidBodyMotion`
 at the given time `t`.
 """
-function rigidbodyvelocity(motion::RigidBodyMotion,t::Real)
+function motion_velocity(motion::RigidBodyMotion,t::Real)
   _,ċ,_,_,α̇,_ = motion(t)
   return [real(ċ),imag(ċ),α̇]
 end
@@ -72,7 +62,7 @@ end
     assign_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                      x::AbstractVector{Float64},y::AbstractVector{Float64},
                      xc::Real,yc::Real,α::Real,
-                     motion,t::Real)
+                     motion::RigidBodyMotion,t::Real)
 
 Assign the components of rigid body velocity `u` and `v` (in inertial coordinate system)
 at positions described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,
@@ -101,7 +91,7 @@ end
 
 """
     assign_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
-                    xc::Real,yc::Real,α::Real,motion,t::Real)
+                    xc::Real,yc::Real,α::Real,motion::RigidBodyMotion,t::Real)
 
 Return the components of rigid body velocities (in inertial components) at positions
 described by coordinates `x`, `y` (also in inertial coordinate system) at time `t`,

--- a/src/rigidtransform.jl
+++ b/src/rigidtransform.jl
@@ -1,6 +1,5 @@
 # Rigid-body transformation routines
 
-import Base: vec
 export RigidTransform
 
 """

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -176,12 +176,12 @@ end
 Rectangle(a::Real,b::Real,na::Int;shifted=true) = _rectangle(a,b,na,Val(shifted))
 
 function _rectangle(a::Real,b::Real,na::Int,::Val{false})
-    x̃, ỹ, ibottom, iright, itop, ileft = _rectangle_points(a::Real,b::Real,na::Int)
+    x̃, ỹ = _rectangle_points(a::Real,b::Real,na::Int)
     Rectangle{length(x̃),Unshifted}(a,b,(0.0,0.0),0.0,x̃,ỹ,x̃,ỹ,nothing,nothing,nothing,nothing)
 end
 
 function _rectangle(a::Real,b::Real,na::Int,::Val{true})
-    x̃mid, ỹmid, ibottom_mid, iright_mid, itop_mid, ileft_mid = _rectangle_points(a::Real,b::Real,na::Int)
+    x̃mid, ỹmid = _rectangle_points(a::Real,b::Real,na::Int)
     x̃, ỹ = _midpoints(x̃mid,ỹmid,ClosedBody)
     Rectangle{length(x̃),Shifted}(a,b,(0.0,0.0),0.0,x̃,ỹ,x̃,ỹ,x̃mid,ỹmid,x̃mid,ỹmid)
 end
@@ -211,14 +211,15 @@ function _rectangle_points(a::Real,b::Real,na::Int)
   @. x[ileft] = -a
   @. y[ileft] =  -b + Δsb*(nb-1:-1:1)
 
-  return x, y, ibottom, iright, itop, ileft
+  return x, y
 
 end
 
 #Rectangle(a::Real,b::Real,targetsize::Float64;kwargs...) =
 #    Rectangle(a,b,_adjustnumber(targetsize,Rectangle,a,b);kwargs...)
 
-centraldiff(b::Rectangle{N,Shifted}) where {N} = _diff(b.xmid,b.ymid,ClosedBody)
+_centraldiff(b::Rectangle{N,Shifted},::Val{false}) where {N} = _diff(b.xmid,b.ymid,ClosedBody)
+_centraldiff(b::Rectangle{N,Shifted},::Val{true}) where {N} = _diff(b.x̃mid,b.ỹmid,ClosedBody)
 
 
 function (T::RigidTransform)(b::Rectangle{N,Shifted}) where {N}

--- a/test/bodies.jl
+++ b/test/bodies.jl
@@ -36,21 +36,28 @@ const MYEPS = 20*eps()
   @test abs(sum(ny)) < 1000.0*eps(1.0)
 
 
+  T = RigidTransform((1.0,-1.0),π/4)
+  T(c)
+  nx2, ny2 = normalmid(c,ref=true)
+  @test sum(abs.(nx .- nx2)) < 1000.0*eps(1.0)
+  @test sum(abs.(ny .- ny2)) < 1000.0*eps(1.0)
+
+
 end
 
 @testset "Shifted rectangle" begin
 
   b = Rectangle(0.5,1.0,11,shifted=true)
-  nx, ny = normalmid(b)
-  nx, ny = normalmid(b)
-  @test all(isapprox.(nx[1:10],0.0,atol=MYEPS)) &&
-        all(isapprox.(nx[11:30],1.0,atol=MYEPS)) &&
-        all(isapprox.(nx[31:40],0.0,atol=MYEPS)) &&
-        all(isapprox.(nx[41:60],-1.0,atol=MYEPS))
-  @test all(isapprox.(ny[1:10],-1.0,atol=MYEPS)) &&
-        all(isapprox.(ny[11:30],0.0,atol=MYEPS)) &&
-        all(isapprox.(ny[31:40],1.0,atol=MYEPS)) &&
-        all(isapprox.(ny[41:60],0.0,atol=MYEPS))
+  nx0, ny0 = normalmid(b)
+
+  @test all(isapprox.(nx0[1:10],0.0,atol=MYEPS)) &&
+        all(isapprox.(nx0[11:30],1.0,atol=MYEPS)) &&
+        all(isapprox.(nx0[31:40],0.0,atol=MYEPS)) &&
+        all(isapprox.(nx0[41:60],-1.0,atol=MYEPS))
+  @test all(isapprox.(ny0[1:10],-1.0,atol=MYEPS)) &&
+        all(isapprox.(ny0[11:30],0.0,atol=MYEPS)) &&
+        all(isapprox.(ny0[31:40],1.0,atol=MYEPS)) &&
+        all(isapprox.(ny0[41:60],0.0,atol=MYEPS))
 
   ds = dlengthmid(b)
   @test all(ds .≈ 0.1)
@@ -70,6 +77,12 @@ end
 
   ds = dlengthmid(b)
   @test all(ds .≈ 0.1)
+
+  T = RigidTransform((1.2,-1.5),π/4)
+  T(b)
+  nx2, ny2 = normalmid(b,ref=true)
+  @test sum(abs.(nx0 .- nx2)) < 1000.0*eps(1.0)
+  @test sum(abs.(ny0 .- ny2)) < 1000.0*eps(1.0)
 
 
 end

--- a/test/bodies.jl
+++ b/test/bodies.jl
@@ -18,12 +18,12 @@ const MYEPS = 20*eps()
   @test sum(dlength(p)) ≈ sum(dlengthmid(p))
 
 
-  c = Rectangle(1,2,101)
+  c = Rectangle(1,2,101,shifted=false)
   dx, dy = diff(c)
   @test length(dx) == 600
   @test sum(dlength(c)) ≈ 12.0
 
-  c = Square(1,0.01)
+  c = Square(1,0.01,shifted=false)
   @test isapprox(mean(dlength(c)),0.01,atol=1e-4)
 
   c = Ellipse(1,2,0.01)
@@ -137,8 +137,8 @@ end
     @test u[26] ≈ -1.0+real(ċ) atol = 1e-14
     @test v[51] ≈ -1.0+imag(ċ) atol = 1e-14
 
-    u2, v2 = m(0.0,b)
-    @test u == u2 && v == v2
+    #u2, v2 = m(0.0,b)
+    #@test u == u2 && v == v2
 
     b2 = Circle(1.0,100)
     T2 = RigidTransform((rand(),rand()),0.0)
@@ -156,7 +156,7 @@ end
     u2, v2 = ml(0.0,bl)
     @test u2 == u && v2 == v
 
-    vel = motion_velocity(ml,0.0)
+    vel = motion_velocity(bl,ml,0.0)
     @test vel[3] == 1.0
     @test vel[1]+im*vel[2] ≈ ċ atol = 1e-14
     @test vel[4]+im*vel[5] ≈ ċ2 atol = 1e-14

--- a/test/bodies.jl
+++ b/test/bodies.jl
@@ -89,9 +89,9 @@ end
   m1 = RigidBodyMotion(complex(0.0),0.0)
   m2 = RigidBodyMotion(RigidBodyTools.PitchHeave(1.0, 11.0, 0.2, 0.0, 0.0, 0.5, 1.0, 0.0))
 
-  ml = RigidMotionList([m1,m2])
+  ml = MotionList([m1,m2])
   @test length(ml) == 2
-  @test eltype(ml) == RigidBodyMotion
+  @test eltype(ml) == RigidBodyTools.AbstractMotion
 
   t1 = RigidTransform((0.0,0.0),0.0)
   t2 = RigidTransform((1.0,0.0),π/2)
@@ -147,7 +147,7 @@ end
     m2 = RigidBodyMotion(ċ2,1.0)
 
     bl = BodyList([b,b2])
-    ml = RigidMotionList([m,m2])
+    ml = MotionList([m,m2])
     u, v = assign_velocity(bl,ml,0.0)
     @test u[26] ≈ -1.0+real(ċ) atol = 1e-14
     @test u[126] ≈ -1.0+real(ċ2) atol = 1e-14
@@ -156,7 +156,7 @@ end
     u2, v2 = ml(0.0,bl)
     @test u2 == u && v2 == v
 
-    vel = rigidbodyvelocity(ml,0.0)
+    vel = motion_velocity(ml,0.0)
     @test vel[3] == 1.0
     @test vel[1]+im*vel[2] ≈ ċ atol = 1e-14
     @test vel[4]+im*vel[5] ≈ ċ2 atol = 1e-14

--- a/test/bodies.jl
+++ b/test/bodies.jl
@@ -133,7 +133,7 @@ end
 
     ċ = rand(ComplexF64)
     m = RigidBodyMotion(ċ,1.0)
-    u,v = assign_velocity(b,m,0.0)
+    u,v = surface_velocity(b,m,0.0)
     @test u[26] ≈ -1.0+real(ċ) atol = 1e-14
     @test v[51] ≈ -1.0+imag(ċ) atol = 1e-14
 
@@ -148,7 +148,7 @@ end
 
     bl = BodyList([b,b2])
     ml = MotionList([m,m2])
-    u, v = assign_velocity(bl,ml,0.0)
+    u, v = surface_velocity(bl,ml,0.0)
     @test u[26] ≈ -1.0+real(ċ) atol = 1e-14
     @test u[126] ≈ -1.0+real(ċ2) atol = 1e-14
     @test v[151] ≈ -1.0+imag(ċ2) atol = 1e-14

--- a/test/motions.jl
+++ b/test/motions.jl
@@ -105,7 +105,7 @@ end
 
 end
 
-@testset "Motion states" begin
+@testset "Motion velocities and states" begin
 
   b1 = Circle(1.0,100)
   b2 = Rectangle(2.0,0.5,400)
@@ -128,6 +128,10 @@ end
   @test x0[1:3] == vec(T1)[1:3]
   @test x0[4:end] == vcat(b2.x,b2.y)
 
+  t = rand()
+  u = motion_velocity(bl,ml,t)
+  @test u[1:3] == motion_velocity(b1,m1,t)
+  @test u[4:end] == motion_velocity(b2,m2,t)
 
 
 end

--- a/test/motions.jl
+++ b/test/motions.jl
@@ -104,3 +104,30 @@ end
 
 
 end
+
+@testset "Motion states" begin
+
+  b1 = Circle(1.0,100)
+  b2 = Rectangle(2.0,0.5,400)
+  bl = BodyList([b1,b2])
+
+  T1 = RigidTransform((rand(),rand()),rand())
+  T2 = RigidTransform((rand(),rand()),rand())
+  tl = RigidTransformList([T1,T2])
+
+  tl(bl)
+
+  kin = Pitchup(1.0,0.5,0.2,0.0,0.5,π/4,EldredgeRamp(20.0))
+  m1 = RigidBodyMotion(kin)
+  m2 = BasicDirectMotion(one.(b2.x),zero.(b2.y))
+
+  ml = MotionList([m1,m2])
+
+  x0 = motion_state(bl,ml)
+
+  @test x0[1:3] == vec(T1)[1:3]
+  @test x0[4:end] == vcat(b2.x,b2.y)
+
+
+
+end

--- a/test/motions.jl
+++ b/test/motions.jl
@@ -95,9 +95,10 @@ end
 
 @testset "Direct motions" begin
 
-  m = RigidBodyTools.BasicDirectMotion()
+  u, v = rand(5), rand(5)
+  m = RigidBodyTools.BasicDirectMotion(u,v)
 
-  ml = RigidBodyTools.DirectlySpecifiedMotionList([m])
+  ml = RigidBodyTools.MotionList([m])
 
   push!(ml,m)
 


### PR DESCRIPTION
This PR creates a more general set of motions and generalizes the notion of motion lists.
- a `DirectlySpecifiedMotion` motion specifies the motion directly on the surface points; a `RigidBodyMotion` specifies the rigid-body coordinates.
- a `MotionList` can contain a mix of `RigidBodyMotion` and `DirectlySpecifiedMotion` motion types. These are each a subtype of `AbstractMotion`.
- it makes it easy to create new motions, simply by defining a struct as a subtype of `DirectlySpecifiedMotion` and extending the function
`surface_velocity!(u,v,b::Body,m::NewMotionType,t)`
- `surface_velocity` replaces `assign_velocity` to provide the values of the velocity on the body surface
- `motion_velocity(b,m,t)` provides a vector of the velocities for advancing the body (which would be the centroid velocity and angular velocity for a rigid body)
- `motion_state(b,m)` returns the current state vector for the body, useful for getting the initial condition for advancing the body.

Also did some other housekeeping, allowing calculations on bodies like `normal`, etc., to optionally use `ref=true` to use the reference coordinates of the body.