### PR TITLE
Use ≈ instead of == to remove false test failure

### DIFF
--- a/test/bodies.jl
+++ b/test/bodies.jl
@@ -21,8 +21,7 @@ const MYEPS = 20*eps()
   @test sum(dlength(c)) ≈ 12.0
 
   s = arccoord(c)
-  @test s[end] ≈ 12.0
-  @test s[end] == arclength(c)
+  @test s[end] ≈ 12.0 ≈ arclength(c)
   smid = arccoordmid(c)
   @test smid[1] > 0.0 && smid[end] < s[end]
 


### PR DESCRIPTION
If approximate equality (i.e. within a few ulps) is acceptable here, then I'd request y'all loosen this test to avoid spurious PkgEval failures like [this](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/ea9a599_vs_c9eccfc/RigidBodyTools.primary.log):
```
...
Bodies: Test Failed at /home/pkgeval/.julia/packages/RigidBodyTools/wOjbR/test/bodies.jl:25
  Expression: s[end] == arclength(c)
   Evaluated: 11.9999999999999 == 11.999999999999993
Stacktrace:
 [1] macro expansion
   @ /opt/julia/share/julia/stdlib/v1.10/Test/src/Test.jl:477 [inlined]
 [2] macro expansion
   @ ~/.julia/packages/RigidBodyTools/wOjbR/test/bodies.jl:25 [inlined]
 [3] macro expansion
   @ /opt/julia/share/julia/stdlib/v1.10/Test/src/Test.jl:1496 [inlined]
 [4] top-level scope
   @ ~/.julia/packages/RigidBodyTools/wOjbR/test/bodies.jl:7
...
```