### PR TITLE
Simplify arclength(::BodyList)

### DIFF
--- a/src/tools.jl
+++ b/src/tools.jl
@@ -291,10 +291,5 @@ Compute the total arclength of each body in `bl` and assemble the
 results into a vector. If `ref=true`, use the body-fixed coordinates.
 """
 function arclength(bl::BodyList;kwargs...)
-  l = Float64[]
-  for b in bl
-      lb = arclength(b;kwargs...)
-      push!(l,lb)
-  end
-  return l
+    [arclength(b;kwargs...) for b in bl]
 end


### PR DESCRIPTION
In addition to simpler code, this change also reduces allocations by letting list comprehension infer the length of the output and automatically preallocate. This version is also more general because it preserves the output type of arclength rather than forcing it to be a `Float64`. For example, if someone was using Unitful.jl they may now be able to get an arclength of `17.29 m` which would previously have thrown an error on conversion to Float64.