### PR TITLE
Fixed the thick plate definition

### DIFF
--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -511,6 +511,9 @@ function ThickPlate(len::Real,thick::Real,N::Int;λ::Float64=1.0)
       push!(x̃end,-xedge[i])
       push!(ỹend,yedge[i])
     end
+    x̃end .= reverse(x̃end)
+    ỹend .= reverse(ỹend)
+
     x̃, ỹ = _midpoints(x̃end,ỹend,ClosedBody)
 
     ThickPlate{length(x̃)}(len,thick,(0.0,0.0),0.0,x̃,ỹ,x̃,ỹ,x̃end,ỹend,x̃end,ỹend)

--- a/test/bodies.jl
+++ b/test/bodies.jl
@@ -22,7 +22,7 @@ const MYEPS = 20*eps()
 
   s = arccoord(c)
   @test s[end] ≈ 12.0
-  @test s[end] == arclength(c)
+  @test s[end] ≈ arclength(c)
   smid = arccoordmid(c)
   @test smid[1] > 0.0 && smid[end] < s[end]
 


### PR DESCRIPTION
The `ThickPlate` was previously defined in clockwise orientation. This reverses the definition so that normals come out correctly.