### PR TITLE
Improved output of kinematics data

### DIFF
--- a/src/RigidBodyTools.jl
+++ b/src/RigidBodyTools.jl
@@ -10,7 +10,12 @@ export RigidBodyMotion, Kinematics, d_dt, motion_velocity, motion_state,
           RigidAndDeformingMotion,maxvelocity, maxlistvelocity
 
 export Oscillation, OscillationX, OscillationY, OscillationXY, RotationalOscillation,
-        PitchHeave, Pitchup, EldredgeRamp, ColoniusRamp, SwitchedKinematics
+        PitchHeave, Pitchup, EldredgeRamp, ColoniusRamp, SwitchedKinematics,
+        complex_translational_position, complex_translational_velocity, complex_translational_acceleration,
+        angular_position, angular_velocity, angular_acceleration,
+        translational_position, translational_velocity, translational_acceleration,
+        KinematicData
+
 
 
 const NDIM = 2

--- a/src/kinematics.jl
+++ b/src/kinematics.jl
@@ -31,70 +31,98 @@ end
 
 # APIs
 """
-    complex_translational_position(k::KinematicData) -> ComplexF64
+    complex_translational_position(k::KinematicData;[inertial=true]) -> ComplexF64
 
-Return the complex translational position of kinematic data `k`
+Return the complex translational position (relative to the initial
+  position) of kinematic data `k`, expressed in inertial coordinates (if `inertial=true`,
+    the default) or in comoving coordinates if `inertial=false`.
 """
-complex_translational_position(k::KinematicData) = k.c
+complex_translational_position(k::KinematicData;inertial::Bool=true) =
+        _complex_translation_position(k,Val(inertial))
+
+_complex_translation_position(k,::Val{true}) = k.c
+_complex_translation_position(k,::Val{false}) = k.c*exp(-im*k.α)
+
 
 """
-    complex_translational_velocity(k::KinematicData) -> ComplexF64
+    complex_translational_velocity(k::KinematicData;[inertial=true]) -> ComplexF64
 
-Return the complex translational velocity of kinematic data `k`
+Return the complex translational velocity of kinematic data `k`, relative
+to inertial reference frame, expressed in inertial coordinates (if `inertial=true`,
+  the default) or in comoving coordinates if `inertial=false`.
 """
-complex_translational_velocity(k::KinematicData) = k.ċ
+complex_translational_velocity(k::KinematicData;inertial::Bool=true) =
+        _complex_translation_velocity(k,Val(inertial))
+
+_complex_translation_velocity(k,::Val{true}) = k.ċ
+_complex_translation_velocity(k,::Val{false}) = k.ċ*exp(-im*k.α)
+
 
 """
-    complex_translational_acceleration(k::KinematicData) -> ComplexF64
+    complex_translational_acceleration(k::KinematicData;[inertial=true]) -> ComplexF64
 
-Return the complex translational acceleration of kinematic data `k`
+Return the complex translational acceleration of kinematic data `k`, relative
+to inertial reference frame, expressed in inertial coordinates (if `inertial=true`,
+  the default) or in comoving coordinates if `inertial=false`.
 """
-complex_translational_acceleration(k::KinematicData) = k.c̈
+complex_translational_acceleration(k::KinematicData;inertial::Bool=true) =
+        _complex_translation_acceleration(k,Val(inertial))
+
+_complex_translation_acceleration(k,::Val{true}) = k.c̈
+_complex_translation_acceleration(k,::Val{false}) = k.c̈*exp(-im*k.α)
 
 """
     angular_position(k::KinematicData) -> Float64
 
-Return the angular orientation of kinematic data `k`
+Return the angular orientation of kinematic data `k`, relative to
+inital value, in the inertial reference frame.
 """
 angular_position(k::KinematicData) = k.α
 
 """
     angular_velocity(k::KinematicData) -> Float64
 
-Return the angular velocity of kinematic data `k`
+Return the angular velocity of kinematic data `k`, relative to
+inertial reference frame.
 """
 angular_velocity(k::KinematicData) = k.α̇
 
 """
     angular_acceleration(k::KinematicData) -> Float64
 
-Return the angular acceleration of kinematic data `k`
+Return the angular acceleration of kinematic data `k`, relative to
+inertial reference frame.
 """
 angular_acceleration(k::KinematicData) = k.α̈
 
 """
-    translational_position(k::KinematicData) -> Tuple
+    translational_position(k::KinematicData;[inertial=true]) -> Tuple
 
-Return the translational position of kinematic data `kin`
-as a Tuple.
+Return the translational position of kinematic data `k` (relative to the initial
+  position), expressed as a Tuple in inertial coordinates (if `inertial=true`,
+    the default) or in comoving coordinates if `inertial=false`.
 """
-translational_position(k::KinematicData) = reim(complex_translational_position(k))
+translational_position(k::KinematicData;kwargs...) =
+          reim(complex_translational_position(k;kwargs...))
+"""
+    translational_velocity(k::KinematicData;[inertial=true]) -> Tuple
+
+Return the translational velocity of kinematic data `k`, relative
+to inertial reference frame, expressed as a Tuple in inertial coordinates (if `inertial=true`,
+  the default) or in comoving coordinates if `inertial=false`.
+"""
+translational_velocity(k::KinematicData;kwargs...) =
+          reim(complex_translational_velocity(k;kwargs...))
 
 """
-    translational_velocity(k::KinematicData) -> Tuple
+    translational_acceleration(k::KinematicData;[inertial=true]) -> Tuple
 
-Return the translational velocity of kinematic data `kin`
-as a Tuple.
+Return the translational acceleration of kinematic data `k`, relative
+to inertial reference frame, expressed as a Tuple in inertial coordinates (if `inertial=true`,
+  the default) or in comoving coordinates if `inertial=false`.
 """
-translational_velocity(k::KinematicData) = reim(complex_translational_velocity(k))
-
-"""
-    translational_acceleration(k::KinematicData) -> Tuple
-
-Return the translational acceleration of kinematic data `kin`
-as a Tuple.
-"""
-translational_acceleration(k::KinematicData) = reim(complex_translational_acceleration(k))
+translational_acceleration(k::KinematicData;kwargs...) =
+          reim(complex_translational_acceleration(k;kwargs...))
 
 
 ####

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -244,26 +244,23 @@ end
 
 Assign the components of velocity `u` and `v` (in inertial coordinate system)
 at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
-based on supplied motions in the MotionList `ml` for each body.  If, instead,
-`inertial=false`, then it is assumed that `u`, `v`, and body coordinates are all
-expressed in comoving coordinates for each body (but velocities are relative to inertial
-  frame). If only one motion is specified in `ml`, then it is assumed that
+based on supplied motions in the MotionList `ml` for each body. If only one motion is specified in `ml`, then it is assumed that
   this is to be applied to all bodies.
 """
 function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 bl::BodyList,ml::MotionList,t::Real;inertial=true)
+                 bl::BodyList,ml::MotionList,t::Real;kwargs...)
 
    for i in 1:length(bl)
-      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],ml[i],t;inertial=inertial)
+      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],ml[i],t;kwargs...)
    end
    return u, v
 end
 
 function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 bl::BodyList,motion::AbstractMotion,t::Real;inertial=true)
+                 bl::BodyList,motion::AbstractMotion,t::Real;kwargs...)
 
    for i in 1:length(bl)
-      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],motion,t;inertial=inertial)
+      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],motion,t;kwargs...)
    end
    return u, v
 end
@@ -274,14 +271,11 @@ end
 
 Return the components of rigid body velocity (in inertial coordinate system)
 at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
-based on supplied motions in the MotionList `ml` for each body.   If, instead,
-`inertial=false`, then it is assumed that velocities and body coordinates are all
-expressed in comoving coordinates for each body (but velocities are relative to inertial
-  frame).  If only one motion is specified in `ml`, then it is assumed that
+based on supplied motions in the MotionList `ml` for each body. If only one motion is specified in `ml`, then it is assumed that
   this is to be applied to all bodies.
 """
-surface_velocity(bl::BodyList,ml::Union{AbstractMotion,MotionList},t::Real;inertial=true) =
-    surface_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t;inertial=inertial)
+surface_velocity(bl::BodyList,ml::Union{AbstractMotion,MotionList},t::Real;kwargs...) =
+    surface_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t;kwargs...)
 
 
 """

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -184,7 +184,7 @@ end
 Returns a concatenation of length-3 vectors of the form [x,y,α] corresponding to the translation
 and rotation specified by the given by the list of transforms `tl`.
 """
-vec(tl::RigidTransformList) where {N} = mapreduce(vec,vcat,tl)
+vec(tl::RigidTransformList) = mapreduce(vec,vcat,tl)
 
 """
     RigidTransformList(x::Vector)

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -240,14 +240,15 @@ end
 
 """
     surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                     bl::BodyList,ml::MotionList,t::Real[;inertial=true])
+                     bl::BodyList,ml::Union{AbstractMotion,MotionList},t::Real[;inertial=true])
 
 Assign the components of velocity `u` and `v` (in inertial coordinate system)
 at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
 based on supplied motions in the MotionList `ml` for each body.  If, instead,
 `inertial=false`, then it is assumed that `u`, `v`, and body coordinates are all
 expressed in comoving coordinates for each body (but velocities are relative to inertial
-  frame).
+  frame). If only one motion is specified in `ml`, then it is assumed that
+  this is to be applied to all bodies.
 """
 function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
                  bl::BodyList,ml::MotionList,t::Real;inertial=true)
@@ -258,17 +259,28 @@ function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64}
    return u, v
 end
 
+function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
+                 bl::BodyList,motion::AbstractMotion,t::Real;inertial=true)
+
+   for i in 1:length(bl)
+      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],motion,t;inertial=inertial)
+   end
+   return u, v
+end
+
+
 """
-    surface_velocity(bl::BodyList,ml::MotionList,t::Real[;inertial=true])
+    surface_velocity(bl::BodyList,ml::Union{AbstractMotion,MotionList},t::Real[;inertial=true])
 
 Return the components of rigid body velocity (in inertial coordinate system)
 at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
 based on supplied motions in the MotionList `ml` for each body.   If, instead,
 `inertial=false`, then it is assumed that velocities and body coordinates are all
 expressed in comoving coordinates for each body (but velocities are relative to inertial
-  frame).
+  frame).  If only one motion is specified in `ml`, then it is assumed that
+  this is to be applied to all bodies.
 """
-surface_velocity(bl::BodyList,ml::MotionList,t::Real;inertial=true) =
+surface_velocity(bl::BodyList,ml::Union{AbstractMotion,MotionList},t::Real;inertial=true) =
     surface_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t;inertial=inertial)
 
 

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -240,30 +240,36 @@ end
 
 """
     surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                     bl::BodyList,ml::MotionList,t::Real)
+                     bl::BodyList,ml::MotionList,t::Real[;inertial=true])
 
 Assign the components of velocity `u` and `v` (in inertial coordinate system)
 at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
-based on supplied motions in the MotionList `ml` for each body.
+based on supplied motions in the MotionList `ml` for each body.  If, instead,
+`inertial=false`, then it is assumed that `u`, `v`, and body coordinates are all
+expressed in comoving coordinates for each body (but velocities are relative to inertial
+  frame).
 """
 function surface_velocity!(u::AbstractVector{Float64},v::AbstractVector{Float64},
-                 bl::BodyList,ml::MotionList,t::Real)
+                 bl::BodyList,ml::MotionList,t::Real;inertial=true)
 
    for i in 1:length(bl)
-      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],ml[i],t)
+      surface_velocity!(view(u,bl,i),view(v,bl,i),bl[i],ml[i],t;inertial=inertial)
    end
    return u, v
 end
 
 """
-    surface_velocity(bl::BodyList,ml::MotionList,t::Real)
+    surface_velocity(bl::BodyList,ml::MotionList,t::Real[;inertial=true])
 
 Return the components of rigid body velocity (in inertial coordinate system)
 at surface positions described by coordinates inertial coordinates in each body in `bl` at time `t`,
-based on supplied motions in the MotionList `ml` for each body.
+based on supplied motions in the MotionList `ml` for each body.   If, instead,
+`inertial=false`, then it is assumed that velocities and body coordinates are all
+expressed in comoving coordinates for each body (but velocities are relative to inertial
+  frame).
 """
-surface_velocity(bl::BodyList,ml::MotionList,t::Real) =
-    surface_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t)
+surface_velocity(bl::BodyList,ml::MotionList,t::Real;inertial=true) =
+    surface_velocity!(zeros(Float64,numpts(bl)),zeros(Float64,numpts(bl)),bl,ml,t;inertial=inertial)
 
 
 """

--- a/src/rigidbodymotions.jl
+++ b/src/rigidbodymotions.jl
@@ -153,9 +153,5 @@ surface_velocity(x::AbstractVector{Float64},y::AbstractVector{Float64},
 
 function show(io::IO, m::RigidBodyMotion)
     println(io, "Rigid Body Motion:")
-    println(io, "  ċ = $(round(m.ċ, digits=2))")
-    println(io, "  c̈ = $(round(m.c̈, digits=2))")
-    println(io, "  α̇ = $(round(m.α̇, digits=2))")
-    println(io, "  α̈ = $(round(m.α̈, digits=2))")
     print(io, "  $(m.kin)")
 end

--- a/test/motions.jl
+++ b/test/motions.jl
@@ -122,6 +122,19 @@ Ay = rand()
   @test complex_translational_velocity(k) ≈ 0.0
   @test complex_translational_acceleration(k) ≈ 0.0
 
+  U₀ = 0.0
+  a = 0.5
+  K = 0.2
+  t₀ = 0.5
+  pu = Pitchup(U₀,a,K,α₀,t₀,Δα,EldredgeRamp(20.0))
+  t = rand()
+  k = pu(t)
+  α̇ = angular_velocity(k)
+  α̈ = angular_acceleration(k)
+
+  @test complex_translational_position(k,inertial=false) ≈ -a
+  @test complex_translational_velocity(k,inertial=false) ≈ -a*im*α̇
+  @test complex_translational_acceleration(k,inertial=false) ≈ a*(α̇^2 - im*α̈)
 
 end
 

--- a/test/motions.jl
+++ b/test/motions.jl
@@ -18,25 +18,47 @@ Ay = rand()
   oscil = RigidBodyTools.Oscillation(Ux,Uy,α̇₀,ax,ay,Ω,Ax,Ay,ϕx,ϕy,α₀,Δα,ϕα)
 
   t = rand()
-  c, ċ, c̈, α,α̇,α̈ = oscil(t)
+  #c, ċ, c̈, α,α̇,α̈ = oscil(t)
+  k = oscil(t)
 
-  @test α ≈ α₀ + α̇₀*t + Δα*sin(Ω*t-ϕα)
-  @test α̇ ≈ α̇₀ + Δα*Ω*cos(Ω*t-ϕα)
-  @test α̈ ≈ -Δα*Ω^2*sin(Ω*t-ϕα)
+
+  @test angular_position(k) ≈ α₀ + α̇₀*t + Δα*sin(Ω*t-ϕα)
+  @test angular_velocity(k) ≈ α̇₀ + Δα*Ω*cos(Ω*t-ϕα)
+  @test angular_acceleration(k) ≈ -Δα*Ω^2*sin(Ω*t-ϕα)
 
   a = complex(ax,ay)
+  α = angular_position(k)
+  α̇ = angular_velocity(k)
+  α̈ = angular_acceleration(k)
+  c = complex_translational_position(k)
+  ċ = complex_translational_velocity(k)
+  c̈ = complex_translational_acceleration(k)
   @test real(c) ≈ Ux*t + Ax*sin(Ω*t-ϕx) - ax*cos(α) + ay*sin(α)
   @test imag(c) ≈ Uy*t + Ay*sin(Ω*t-ϕy) - ay*cos(α) - ax*sin(α)
   @test real(ċ) ≈ Ux + Ax*Ω*cos(Ω*t-ϕx) + α̇*(ax*sin(α) + ay*cos(α))
   @test imag(ċ) ≈ Uy + Ay*Ω*cos(Ω*t-ϕy) + α̇*(ay*sin(α) - ax*cos(α))
   @test real(c̈) ≈ -Ax*Ω^2*sin(Ω*t-ϕx) + α̈*(ax*sin(α) + ay*cos(α)) + α̇^2*(ax*cos(α) - ay*sin(α))
   @test imag(c̈) ≈ -Ay*Ω^2*sin(Ω*t-ϕy) + α̈*(ay*sin(α) - ax*cos(α)) + α̇^2*(ay*cos(α) + ax*sin(α))
+  @test isa(translational_position(k),Tuple)
+  @test isa(translational_velocity(k),Tuple)
+  @test isa(translational_acceleration(k),Tuple)
+  @test translational_position(k) == reim(c)
+  @test translational_velocity(k) == reim(ċ)
+  @test translational_acceleration(k) == reim(c̈)
 
 
   ph = RigidBodyTools.PitchHeave(Ux,ax,Ω,α₀,Δα,ϕα,Ay,ϕy)
 
   t = rand()
-  c, ċ, c̈, α,α̇,α̈ = ph(t)
+  #c, ċ, c̈, α,α̇,α̈ = ph(t)
+  k = ph(t)
+
+  α = angular_position(k)
+  α̇ = angular_velocity(k)
+  α̈ = angular_acceleration(k)
+  c = complex_translational_position(k)
+  ċ = complex_translational_velocity(k)
+  c̈ = complex_translational_acceleration(k)
 
   @test α ≈ α₀ + Δα*sin(Ω*t-ϕα)
   @test α̇ ≈ Δα*Ω*cos(Ω*t-ϕα)
@@ -52,43 +74,53 @@ Ay = rand()
   ox = RigidBodyTools.OscillationX(Ux,Ω,Ax,ϕx)
 
   t = rand()
-  c, ċ, c̈, α,α̇,α̈ = ox(t)
-  @test α ≈ 0.0
-  @test α̇ ≈ 0.0
-  @test α̈ ≈ 0.0
-  @test real(c) ≈ Ux*t + Ax*sin(Ω*t-ϕx)
-  @test imag(c) ≈ 0.0
-  @test real(ċ) ≈ Ux + Ax*Ω*cos(Ω*t-ϕx)
-  @test imag(ċ) ≈ 0.0
-  @test real(c̈) ≈ -Ax*Ω^2*sin(Ω*t-ϕx)
-  @test imag(c̈) ≈ 0.0
+  #c, ċ, c̈, α,α̇,α̈ = ox(t)
+  k = ox(t)
+
+  @test angular_position(k) ≈ 0.0
+  @test angular_velocity(k) ≈ 0.0
+  @test angular_acceleration(k) ≈ 0.0
+  xc, yc = translational_position(k)
+  uc, vc = translational_velocity(k)
+  axc, ayc = translational_acceleration(k)
+  @test xc ≈ Ux*t + Ax*sin(Ω*t-ϕx)
+  @test yc ≈ 0.0
+  @test uc ≈ Ux + Ax*Ω*cos(Ω*t-ϕx)
+  @test vc ≈ 0.0
+  @test axc ≈ -Ax*Ω^2*sin(Ω*t-ϕx)
+  @test ayc ≈ 0.0
 
   oy = RigidBodyTools.OscillationY(Uy,Ω,Ay,ϕy)
 
   t = rand()
-  c, ċ, c̈, α,α̇,α̈ = oy(t)
-  @test α ≈ 0.0
-  @test α̇ ≈ 0.0
-  @test α̈ ≈ 0.0
-  @test real(c) ≈ 0.0
-  @test imag(c) ≈ Uy*t + Ay*sin(Ω*t-ϕy)
-  @test real(ċ) ≈ 0.0
-  @test imag(ċ) ≈ Uy + Ay*Ω*cos(Ω*t-ϕy)
-  @test real(c̈) ≈ 0.0
-  @test imag(c̈) ≈ -Ay*Ω^2*sin(Ω*t-ϕy)
+  #c, ċ, c̈, α,α̇,α̈ = oy(t)
+  k = oy(t)
+
+  @test angular_position(k) ≈ 0.0
+  @test angular_velocity(k) ≈ 0.0
+  @test angular_acceleration(k) ≈ 0.0
+  xc, yc = translational_position(k)
+  uc, vc = translational_velocity(k)
+  axc, ayc = translational_acceleration(k)
+  @test xc ≈ 0.0
+  @test yc ≈ Uy*t + Ay*sin(Ω*t-ϕy)
+  @test uc ≈ 0.0
+  @test vc ≈ Uy + Ay*Ω*cos(Ω*t-ϕy)
+  @test axc ≈ 0.0
+  @test ayc ≈ -Ay*Ω^2*sin(Ω*t-ϕy)
 
   ro = RigidBodyTools.RotationalOscillation(Ω,Δα,ϕα)
 
   t = rand()
-  c, ċ, c̈, α,α̇,α̈ = ro(t)
+  #c, ċ, c̈, α,α̇,α̈ = ro(t)
+  k = ro(t)
 
-  @test α ≈ Δα*sin(Ω*t-ϕα)
-  @test α̇ ≈ Δα*Ω*cos(Ω*t-ϕα)
-  @test α̈ ≈ -Δα*Ω^2*sin(Ω*t-ϕα)
-  @test c ≈ 0.0
-  @test ċ ≈ 0.0
-  @test c̈ ≈ 0.0
-
+  @test angular_position(k) ≈ Δα*sin(Ω*t-ϕα)
+  @test angular_velocity(k) ≈ Δα*Ω*cos(Ω*t-ϕα)
+  @test angular_acceleration(k) ≈ -Δα*Ω^2*sin(Ω*t-ϕα)
+  @test complex_translational_position(k) ≈ 0.0
+  @test complex_translational_velocity(k) ≈ 0.0
+  @test complex_translational_acceleration(k) ≈ 0.0
 
 
 end


### PR DESCRIPTION
Previously, evaluating kinematics or motion at an instant would output the kinematic data as a long tuple. This PR changes the output of kinematics and rigid-body motion to specialized type `KinematicsData`, coupled with convenience functions to access specific kinematic data. As a result, this is a breaking PR.