### PR TITLE
Lazy views of angular and linear parts of Plucker vectors

### DIFF
--- a/src/rigidbodymotions.jl
+++ b/src/rigidbodymotions.jl
@@ -311,7 +311,7 @@ function body_velocities(x::AbstractVector,t::Real,ls::RigidBodyMotion{ND}) wher
     return PluckerMotionList(vl)
 end
 
-function _child_velocity_from_parent!(vl,vp::PluckerMotion,jid::Int,x::AbstractVector,t::Real,ls::RigidBodyMotion)
+function _child_velocity_from_parent!(vl,vp::AbstractPluckerMotionVector,jid::Int,x::AbstractVector,t::Real,ls::RigidBodyMotion)
     @unpack joints, child_joints = ls
 
     joint = joints[jid]
@@ -335,7 +335,7 @@ function _child_velocity_from_parent!(vl,vp::PluckerMotion,jid::Int,x::AbstractV
 end
 
 
-function _child_velocity_from_parent(Xp_to_ch::MotionTransform,vp::PluckerMotion,XJ_to_ch::MotionTransform,vJ::PluckerMotion)
+function _child_velocity_from_parent(Xp_to_ch::MotionTransform,vp::AbstractPluckerMotionVector,XJ_to_ch::MotionTransform,vJ::AbstractPluckerMotionVector)
     vch = Xp_to_ch*vp + XJ_to_ch*vJ
 end
 
@@ -606,23 +606,23 @@ _body_velocity(v::PluckerMotion,::Val{:full}) = v
 _body_velocity(v::PluckerMotion,::Val{:angular}) = angular_only(v)
 _body_velocity(v::PluckerMotion,::Val{:linear}) = linear_only(v)
 
-function velocity_in_body_coordinates_2d(x̃,ỹ,vb::PluckerMotion{2})
+function velocity_in_body_coordinates_2d(x̃,ỹ,vb::AbstractPluckerMotionVector{2})
     Xb_to_p = MotionTransform(x̃,ỹ,0.0)
     Xb_to_p*vb
 end
 
-function velocity_in_inertial_coordinates_2d(x̃,ỹ,vb::PluckerMotion{2},Xb_to_0::MotionTransform{2})
+function velocity_in_inertial_coordinates_2d(x̃,ỹ,vb::AbstractPluckerMotionVector{2},Xb_to_0::MotionTransform{2})
     rotation_transform(Xb_to_0)*velocity_in_body_coordinates_2d(x̃,ỹ,vb)
 end
 
-function velocity_in_body_coordinates_2d!(u::AbstractVector,v::AbstractVector,b::Body,vb::PluckerMotion{2})
+function velocity_in_body_coordinates_2d!(u::AbstractVector,v::AbstractVector,b::Body,vb::AbstractPluckerMotionVector{2})
     for i in 1:numpts(b)
         vp = velocity_in_body_coordinates_2d(b.x̃[i],b.ỹ[i],vb)
         u[i], v[i] = vp.linear
     end
 end
 
-function _surface_velocity!(u::AbstractVector,v::AbstractVector,b::Body,vb::PluckerMotion{2},deformation::AbstractDeformationMotion,Rb_to_0::MotionTransform{2},t)
+function _surface_velocity!(u::AbstractVector,v::AbstractVector,b::Body,vb::AbstractPluckerMotionVector{2},deformation::AbstractDeformationMotion,Rb_to_0::MotionTransform{2},t)
     u .= 0.0
     v .= 0.0
     _surface_velocity!(u,v,b,deformation,t)

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -99,24 +99,18 @@ end
   vA = PluckerMotion(rand(3))
 
   vAr = angular_only(vA)
-  @test vA.angular == vAr.angular
-  @test all(vAr.linear .== 0.0)
+  @test RigidBodyTools._get_angular_part(vA) === RigidBodyTools._get_angular_part(vAr)
 
   vAl = linear_only(vA)
-  @test vA.linear == vAl.linear
-  @test all(vAl.angular .== 0.0)
+  @test RigidBodyTools._get_linear_part(vA) === RigidBodyTools._get_linear_part(vAl)
 
   vA = PluckerMotion(rand(6))
 
   vAr = angular_only(vA)
-  @test vA.angular == vAr.angular
-  @test all(vAr.linear .== 0.0)
+  @test RigidBodyTools._get_angular_part(vA) === RigidBodyTools._get_angular_part(vAr)
 
   vAl = linear_only(vA)
-  @test vA.linear == vAl.linear
-  @test all(vAl.angular .== 0.0)
-
-  @test vAr + vAl == vA
+  @test RigidBodyTools._get_linear_part(vA) === RigidBodyTools._get_linear_part(vAl)
 
   x = (rand(),rand())
   θ = rand()
@@ -127,24 +121,18 @@ end
   vA = PluckerForce(rand(3))
 
   vAr = angular_only(vA)
-  @test vA.angular == vAr.angular
-  @test all(vAr.linear .== 0.0)
+  @test RigidBodyTools._get_angular_part(vA) === RigidBodyTools._get_angular_part(vAr)
 
   vAl = linear_only(vA)
-  @test vA.linear == vAl.linear
-  @test all(vAl.angular .== 0.0)
+  @test RigidBodyTools._get_linear_part(vA) === RigidBodyTools._get_linear_part(vAl)
 
   vA = PluckerForce(rand(6))
 
   vAr = angular_only(vA)
-  @test vA.angular == vAr.angular
-  @test all(vAr.linear .== 0.0)
+  @test RigidBodyTools._get_angular_part(vA) === RigidBodyTools._get_angular_part(vAr)
 
   vAl = linear_only(vA)
-  @test vA.linear == vAl.linear
-  @test all(vAl.angular .== 0.0)
-
-  @test vAr + vAl == vA
+  @test RigidBodyTools._get_linear_part(vA) === RigidBodyTools._get_linear_part(vAl)
 
   x = (rand(),rand())
   θ = rand()
@@ -152,19 +140,38 @@ end
   vA = PluckerForce(rand(3))
   TM*vA
 
+  TM*angular_only(vA)
+
+  TM*linear_only(vA)
+
+
+  TM = MotionTransform(x,θ)
   vA = PluckerMotion{2}(angular=1)
   vB = PluckerMotion([1,2,3])
-  @test angular_only(vA) == angular_only(vB)
+  @test TM*angular_only(vA) == TM*angular_only(vB)
 
   vA = PluckerMotion{2}(linear=[2,3])
-  @test linear_only(vA) == linear_only(vB)
+  @test TM*linear_only(vA) == TM*linear_only(vB)
 
+  TM = MotionTransform(rand(3),rotation_about_axis(rand(),rand(3)))
   vA = PluckerMotion{3}(angular=[1,2,3])
   vB = PluckerMotion([1,2,3,4,5,6])
-  @test angular_only(vA) == angular_only(vB)
+  @test TM*angular_only(vA) == TM*angular_only(vB)
 
   vA = PluckerMotion{3}(linear=[4,5,6])
-  @test linear_only(vA) == linear_only(vB)
+  @test TM*linear_only(vA) == TM*linear_only(vB)
+
+  vA = PluckerMotion(rand(3))
+  fA = PluckerForce(rand(3))
+
+  @test dot(angular_only(fA),vA) == dot(fA,angular_only(vA)) == dot(angular_only(vA),fA) == dot(vA,angular_only(fA))
+  @test dot(linear_only(fA),vA) == dot(fA,linear_only(vA)) == dot(linear_only(vA),fA) == dot(vA,linear_only(fA))
+
+  vA = PluckerMotion(rand(6))
+  fA = PluckerForce(rand(6))
+
+  @test dot(angular_only(fA),vA) == dot(fA,angular_only(vA)) == dot(angular_only(vA),fA) == dot(vA,angular_only(fA))
+  @test dot(linear_only(fA),vA) == dot(fA,linear_only(vA)) == dot(linear_only(vA),fA) == dot(vA,linear_only(fA))
 
 
 end


### PR DESCRIPTION
This PR allows lazy views of angular and linear parts of Plucker vectors, using `angular_only(v)` and `linear_only(v)`.