### PR TITLE
update ismoving for exogenous dofs

### DIFF
--- a/src/joints.jl
+++ b/src/joints.jl
@@ -95,7 +95,7 @@ number_of_dofs(j::Joint{ND,JT}) where {ND,JT} = number_of_dofs(JT)
 
 function ismoving(joint::Joint)
     @unpack edofs, udofs, kins = joint
-    any(map(dof -> ismoving(dof),kins)) || !isempty(edofs)
+    any(map(dof -> ismoving(dof),kins)) || !isempty(edofs) || !isempty(udofs)
 end
 
 

--- a/src/joints.jl
+++ b/src/joints.jl
@@ -94,8 +94,8 @@ position_dimension(j::Joint{ND,JT}) where {ND,JT} = position_dimension(JT)
 number_of_dofs(j::Joint{ND,JT}) where {ND,JT} = number_of_dofs(JT)
 
 function ismoving(joint::Joint)
-    @unpack kins = joint
-    any(map(dof -> ismoving(dof),kins))
+    @unpack edofs, kins = joint
+    any(map(dof -> ismoving(dof),kins)) || !isempty(edofs)
 end
 
 

--- a/src/joints.jl
+++ b/src/joints.jl
@@ -94,7 +94,7 @@ position_dimension(j::Joint{ND,JT}) where {ND,JT} = position_dimension(JT)
 number_of_dofs(j::Joint{ND,JT}) where {ND,JT} = number_of_dofs(JT)
 
 function ismoving(joint::Joint)
-    @unpack edofs, kins = joint
+    @unpack edofs, udofs, kins = joint
     any(map(dof -> ismoving(dof),kins)) || !isempty(edofs)
 end
 


### PR DESCRIPTION
For systems with only exogenous dofs, `ismoving` always returns `false` (and, consequently, `immersedlayers.jl` systems won't update). This PR proposes a fix where `ismoving` for joints with non-empty `edofs` always returns `true`. There might be a better way to do this, plus I am also wondering if a non-empty `udofs` has to be treated in the same way.