### PR TITLE
Added rebase_from_inertial_to_reference

### DIFF
--- a/docs/src/manual/joints.md
+++ b/docs/src/manual/joints.md
@@ -377,6 +377,7 @@ update_exogenous!
 maxvelocity
 ismoving(::RigidBodyMotion)
 is_system_in_relative_motion
+rebase_from_inertial_to_reference
 ```
 
 ## Joint types

--- a/src/RigidBodyTools.jl
+++ b/src/RigidBodyTools.jl
@@ -17,7 +17,8 @@ export RigidBodyMotion, AbstractKinematics, d_dt, motion_velocity, motion_state,
           surface_velocity!, surface_velocity, update_body!, transform_body!,
           AbstractDeformationMotion, ConstantDeformationMotion, DeformationMotion,
           NullDeformationMotion,maxvelocity, zero_body, update_exogenous!,
-          zero_exogenous, body_velocities, velocity_in_body_coordinates_2d
+          zero_exogenous, body_velocities, velocity_in_body_coordinates_2d,
+          rebase_from_inertial_to_reference
 
 export parent_body_of_joint, child_body_of_joint, parent_joint_of_body, child_joints_of_body,
         position_vector,velocity_vector,deformation_vector, exogenous_position_vector,

--- a/src/rigidbodymotions.jl
+++ b/src/rigidbodymotions.jl
@@ -597,6 +597,22 @@ function update_exogenous!(ls::RigidBodyMotion,a_edof::AbstractVector)
   nothing
 end
 
+
+"""
+    rebase_from_inertial_to_reference(Xi_to_A::MotionTransform,x::AbstractVector,m::RigidBodyMotion,reference_body::Int)
+
+If `Xi_to_A` represents a motion transform from the inertial coordinates to some
+other coordinates A, such as that of a body, then this function returns a motion transform from
+the reference body coordinates to coordinates A. It uses the current joint
+state vector `x` to construct the transform list of the system `m`.
+"""
+function rebase_from_inertial_to_reference(Xi_to_A::MotionTransform{ND},x::AbstractVector,m::RigidBodyMotion,reference_body::Int) where {ND}
+    Xl = body_transforms(x,m)
+    Xi_to_ref = _reference_transform(Xl,ND,Val(reference_body))
+    Xref_to_A = Xi_to_A*inv(Xi_to_ref)
+    return Xref_to_A
+end
+
 ### Surface velocity API ###
 
 """

--- a/test/literate/joints.jl
+++ b/test/literate/joints.jl
@@ -354,6 +354,7 @@ Let's use it here
 #md # maxvelocity
 #md # ismoving(::RigidBodyMotion)
 #md # is_system_in_relative_motion
+#md # rebase_from_inertial_to_reference
 #md # ```
 
 #md # ## Joint types

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -244,4 +244,14 @@ end
   lsid = 2 # now this system is no longer internally fixed, because body 5 deforms
   @test is_system_in_relative_motion(lsid,ls)
 
+  x = init_motion_state(bl,ls)
+  Xl = body_transforms(x,ls)
+  X1_to_2 = rebase_from_inertial_to_reference(Xl[2],x,ls,1)
+  X0_to_2 = X1_to_2*Xl[1]
+  @test X0_to_2.x ≈ Xl[2].x && X0_to_2.R ≈ Xl[2].R
+
+  X1_to_4 = rebase_from_inertial_to_reference(Xl[4],x,ls,1)
+  X0_to_4 = X1_to_4*Xl[1]
+  @test X0_to_4.x ≈ Xl[4].x && X0_to_4.R ≈ Xl[4].R
+
 end


### PR DESCRIPTION
Creates a function `rebase_from_inertial_to_reference` which takes an existing motion transform from the inertial system and rebases it at a reference body's coordinate system. The function signature is

```rebase_from_inertial_to_reference(Xi_to_A::MotionTransform,x,m::RigidBodyMotion,reference_body)```

where `x` is a joint state vector. It returns another `MotionTransform`